### PR TITLE
Avoid CS4014 in test code

### DIFF
--- a/Assets/Tests/Runtime/基本インタフェース.cs
+++ b/Assets/Tests/Runtime/基本インタフェース.cs
@@ -25,7 +25,7 @@ namespace CAFU.Core.Tests.Runtime
             InstallBasicInterfaceBindings<IAsyncInitializeNotifiable>();
             await UniTask.DelayFrame(1);
             var mock = Container.Resolve<IAsyncInitializeNotifiable>();
-            mock.ReceivedWithAnyArgs(1).NotifyAsync();
+            await mock.ReceivedWithAnyArgs(1).NotifyAsync();
         });
 
         [UnityTest]
@@ -45,7 +45,7 @@ namespace CAFU.Core.Tests.Runtime
             Container.ResolveAll<IDisposable>().First(x => x.GetType() == typeof(TestController)).Dispose();
             await UniTask.DelayFrame(1);
             var mock = Container.Resolve<IAsyncFinalizeNotifiable>();
-            mock.ReceivedWithAnyArgs(1).NotifyAsync();
+            await mock.ReceivedWithAnyArgs(1).NotifyAsync();
         });
 
         private void InstallBasicInterfaceBindings<TInterface>() where TInterface : class


### PR DESCRIPTION
## What

Remove warning:

```
CS4014: Because this call is not awaited, execution of the current method continues before the call is completed. Consider applying the 'await' operator to the result of the call.
```